### PR TITLE
adding newly introduced CRI_RUNTIME_ENDPOINT env-var to daemonset.yaml

### DIFF
--- a/charts/alaz/README.md
+++ b/charts/alaz/README.md
@@ -45,5 +45,6 @@ The following table lists the configurable parameters of the Alaz chart and thei
 | `tracingEnabled` | Enable tracing (service map and distributed tracing) using eBPF | bool | `true` |
 | `logsEnabled` | Enable logging | bool | `false` |
 | `excludedNamespaces` | Namespaces to exclude from monitoring with regex format. For example: `"^anteon.*"` to exclude all namespaces starting with "anteon" | string | `""` |
+| `criRuntimeEndpoint` | Custom CRI runtime endpoint (optional) | string | `""` |
 
 You can override these default values by creating a `values.yaml` file and specifying your own values or using the `--set` flag during installation.

--- a/charts/alaz/templates/daemonset.yaml
+++ b/charts/alaz/templates/daemonset.yaml
@@ -35,6 +35,8 @@ spec:
           value: "{{ .Values.excludedNamespaces }}"
         - name: MONITORING_ID
           value: {{ .Values.monitoringID }}
+        - name: CRI_RUNTIME_ENDPOINT
+          value: {{ .Values.criRuntimeEndpoint }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -59,7 +61,7 @@ spec:
             cpu: {{ .Values.resources.requests.cpu }}
             memory: {{ .Values.resources.requests.memory }}
         securityContext:
-          privileged: true 
+          privileged: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         # needed for linking ebpf trace programs

--- a/charts/alaz/values.schema.json
+++ b/charts/alaz/values.schema.json
@@ -19,6 +19,10 @@
         "type": "string",
         "description": "Monitoring ID (required). You can get it from Anteon Platform"
       },
+      "criRuntimeEndpoint": {
+        "type": "string",
+        "description": "Custom CRI runtime endpoint (optional)"
+      },
       "logLevel": {
         "type": "integer",
         "description": "Zero log level",
@@ -105,4 +109,3 @@
     },
     "required": ["namespace", "backendHost", "monitoringID", "logLevel", "resources", "image", "imagePullPolicy", "containerPort", "metricsEnabled", "tracingEnabled", "logsEnabled"]
   }
-  

--- a/charts/alaz/values.yaml
+++ b/charts/alaz/values.yaml
@@ -2,6 +2,7 @@ namespace: anteon
 
 backendHost: https://api-alaz.getanteon.com:443
 monitoringID: ""  # required
+criRuntimeEndpoint: "" # optional, specifies an additional CRI Runtime Endpoint, e.g. rke2 + containerd via k3s: unix:///run/k3s/containerd/containerd.sock
 logLevel: 1   # zero log levels: -1: trace, 0: debug, 1: info, 2: warn, 3: error, 4: fatal, 5: panic
 
 resources:
@@ -26,7 +27,7 @@ tracingEnabled: true
 # enable logs
 logsEnabled: true
 
-# exclude namespaces from tracing, metrics and logs. 
+# exclude namespaces from tracing, metrics and logs.
 # Regex pattern to exclude namespaces.
-# Example: "^anteon.*" 
+# Example: "^anteon.*"
 excludedNamespaces: ""


### PR DESCRIPTION
adding newly introduced CRI_RUNTIME_ENDPOINT env-var to daemonset.yaml/values.yaml (see https://github.com/getanteon/alaz/issues/163)